### PR TITLE
Fix profile layout (from past merge mishap)

### DIFF
--- a/frontend/styles/profile.css
+++ b/frontend/styles/profile.css
@@ -74,7 +74,6 @@ body {
     padding-top: 2vh;
     margin: 0;
     max-width: 100%;
-
     box-sizing: border-box;
 }
 
@@ -115,8 +114,6 @@ body {
 #goal-wrapper {
     display: flex;
     flex-direction: column;
-
-    align-items: center;
     max-width: 100%;
 }
 
@@ -163,10 +160,7 @@ body {
     height: fit-content;
     padding: 1vh;
     border-radius: 100%;
-
-
     border: white 0.2vh solid;
-
     color: white;
     font-size: x-large;
     cursor: pointer;
@@ -248,14 +242,12 @@ body {
 #garden-display-wrapper {
     display: flex;
     flex-direction: column;
-
     /* align-items: center; */
 
     width: 70vw;
     padding-top: 2vh;
     margin: 0;
     max-width: 100%;
-
 }
 
 #garden-display {


### PR DESCRIPTION
goal-wrapper had an align-items center which was distorting the page. Reverted it back to its old layout.